### PR TITLE
引数の修正とそれに付随する構造の変更をしました

### DIFF
--- a/src/model/optionType.js
+++ b/src/model/optionType.js
@@ -6,12 +6,6 @@ import displayTextSettingType from "./displayTextSettingType.js";
 export default class optionType {
     constructor() {
         /**
-         * storyScriptをセクションごとに保持する配列
-         * @type {storyScriptType[]}
-         */
-        this.storyScript = [new storyScriptType()];
-
-        /**
          * innerBoxのスタイルを設定するためのオブジェクト
          *     肥大化した場合外部ライブラリの導入も検討中
          * @type {innerBoxStyleType}

--- a/src/model/private.js
+++ b/src/model/private.js
@@ -1,8 +1,18 @@
 import positionType from "./positionType.js"
 import flagType from "./flagType.js"
+import storyScriptType from "./storyScriptType.js";
 
 export default class privateType {
-    constructor() {
+    /**
+     *
+     * @param {storyScriptType} storyScript
+     */
+    constructor(storyScript) {
+        /**
+         *
+         * @type {storyScriptType[]}
+         */
+        this.storyScript = [storyScript];
         this.position = new positionType();
         this.flag = new flagType();
     }

--- a/src/test/check_vino_instance/index.html
+++ b/src/test/check_vino_instance/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>$Title$</title>
+</head>
+<body>
+$END$
+</body>
+</html>

--- a/src/test/check_vino_instance/index.html
+++ b/src/test/check_vino_instance/index.html
@@ -2,9 +2,29 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>$Title$</title>
+    <title>check vino instance</title>
+    <link href="../../libs/bootstrap-reboot.min.css" rel="stylesheet">
+    <style>
+        #app {
+            height: 600px;
+            width: 800px;
+            border: thin solid black;
+        }
+    </style>
 </head>
 <body>
-$END$
+<div id="app"></div>
+<script type="module">
+    import vino from "../../vino.js"
+
+    let client = new vino("app", {
+        init: {
+            bgColor: "#9E9E9E",
+        },
+        script: ["hello everyone.", "this is test section", "bye"],
+    }, {});
+
+    console.log(client);
+</script>
 </body>
 </html>

--- a/src/vino.js
+++ b/src/vino.js
@@ -6,9 +6,10 @@ export default class vino {
     /**
      *
      * @param {string} mount
+     * @param {storyScriptType} storyScript
      * @param {Object} userOptions
      */
-    constructor(mount, userOptions) {
+    constructor(mount, storyScript, userOptions) {
         let self = this;
         /**
          * 様々な設定類を格納するオブジェクト
@@ -62,4 +63,8 @@ export default class vino {
 
         initController.run(mount, this.options);
     }
+
+    addStoryScript(storyScript) {
+        this._private.storyScript.push(storyScript);
+    };
 }

--- a/src/vino.js
+++ b/src/vino.js
@@ -21,32 +21,34 @@ export default class vino {
          * @type {privateType}
          * @private {privateType}
          */
-        this._private = new privateType();
+        this._private = new privateType(storyScript);
         /**
          * プライベートな状態を外から見るためのObjectです
          * @type {{character: (function(): number), sentence: (function(): number), section: (function(): number)}}
          */
         this.state = {
-            /**
-             * 何文字目にいるかを受け取るゲッター
-             * @returns {number}
-             */
-            get character() {
-                return self._private.position.character;
-            },
-            /**
-             * 何文目にいるかを受け取るゲッター
-             * @returns {number}
-             */
-            get sentence() {
-                return self._private.position.sentence;
-            },
-            /**
-             * 何セクション目にいるか受け取るゲッター
-             * @returns {number}
-             */
-            get section() {
-                return self._private.position.section;
+            position: {
+                /**
+                 * 何文字目にいるかを受け取るゲッター
+                 * @returns {number}
+                 */
+                get character() {
+                    return self._private.position.character;
+                },
+                /**
+                 * 何文目にいるかを受け取るゲッター
+                 * @returns {number}
+                 */
+                get sentence() {
+                    return self._private.position.sentence;
+                },
+                /**
+                 * 何セクション目にいるか受け取るゲッター
+                 * @returns {number}
+                 */
+                get section() {
+                    return self._private.position.section;
+                }
             }
         };
 


### PR DESCRIPTION
issue #5 の通り、storyScriptのないVinoの使い方は考えにくく、Optionにおいておくのは間違いなので修正しました。
storyScriptを第二引数として取り、`_private`に置きました。
加えてstoryScriptをあとから追加する場合(ex:セクションごとにfetchするなど)のために`addStoryScript`メソッドを用意し、付け加えられるようにしました。
